### PR TITLE
StyleTransform bug fixes and optimizations.

### DIFF
--- a/src/runtime/styles.js
+++ b/src/runtime/styles.js
@@ -11,33 +11,37 @@
  *
  */
 
-module.exports = function styles(mainValue, ...subValues) {
-    function camelCase(str) {
-        return str.replace(/-+([^-]?)/g, function(match, x) {
-            return x.toUpperCase();
-        });
-    }
+function camelCase(str) {
+    return str.replace(/-+([^-]?)/g, function(match, x) {
+        return x.toUpperCase();
+    });
+}
 
-    var key;
-    var resultObject = {};
-    if (typeof mainValue === 'string') {
-        mainValue.split(';').forEach(function(item) {
+function mergeStyleIntoObject(value, obj) {
+    if (typeof value === 'string') {
+        value.split(';').forEach(function(item) {
             const kv = item.split(':', 2);
             if (kv.length === 2) {
-                resultObject[camelCase(kv[0].trim())] = kv[1].trim();
+                obj[camelCase(kv[0].trim())] = kv[1].trim();
             }
         });
     }
-    else if (mainValue) {
-        for (key in mainValue) {
-            resultObject[camelCase(key)] = mainValue[key];
+    else if (value) {
+        for (let key in value) {
+            obj[camelCase(key)] = value[key];
         }
     }
-    // XXX: We can't use Object.assign() here because another babel plugin tries to optimize it out.
-    for (let i = 0; i < subValues.length; i++) {
-        for (key in subValues[i]) {
-            resultObject[camelCase(key)] = subValues[i][key];
-        }
+}
+
+/**
+ * Merge all arguments into one style object. Strings are converted to style objects; object keys are camelCased.
+ * @param {...string|object} values
+ * @return {object}
+ */
+module.exports = function styles(...values) {
+    let resultObject = {};
+    for (let i = 0, len = values.length; i < len; i++) {
+        mergeStyleIntoObject(values[i], resultObject);
     }
     return resultObject;
 };

--- a/src/transforms/StyleAttributeTransform.js
+++ b/src/transforms/StyleAttributeTransform.js
@@ -16,83 +16,177 @@ const t = require('babel-types');
 const camelCaseHyphens = require('@twist/babel-plugin-transform/src/camelCaseHyphens');
 const styles = require('../runtime/styles');
 
+/**
+ * Enable string style attributes, style shorthand attributes, and multiple style attributes.
+ *
+ * 1. String Attributes: React only allows objects as style attribute values (e.g. `{ color: 'red' }`).
+ *    This allows the style attribute to be specified as a string (like in plain HTML).
+ * 2. Style Shorthand: `<div style-background-color="red" />` === `<div style={{ backgroundColor: 'red' }} />`.
+ * 3. Multiple Style Attributes: `<div style={A} style={B} />` is roughly equivalent to `<div style={merge(A, B)}>`.
+ *
+ * Whenever possible, we perform these conversions statically, avoiding any runtime overhead. At compile-time, we:
+ *
+ *  - parse style strings (including `style="..."`, `style={'...'}`, and `style={`...`}`) into objects;
+ *  - combine multiple style attributes and/or shorthands together
+ *
+ * Styles are combined at runtime only when necessary (using the "styles" runtime helper). This happens when:
+ *
+ *  - styles are specified as opaque JS expressions, or interpolated template strings;
+ *  - spread attributes are included along with styles (spreads might include a "style" property).
+ *
+ * As in React, style attributes and shorthands are evaluated left-to-right. We take care to ensure this order
+ * is preserved, even in the presence of spread attributes.
+ */
 module.exports = class StyleAttributeTransform {
+
     static apply(path, state) {
-        let attr = PathUtils.getAttribute(path, 'style');
-
-        // If the user provided a string `style` attribute, parse out the individual properties now. Otherwise,
-        // treat the `style` attribute (mainValue) as an opaque value.
-        let mainValue;
-        const subValues = [];
-        if (attr) {
-            if (t.isStringLiteral(attr.value)) {
-                let obj = styles(attr.value.value, null);
-                for (let key in obj) {
-                    subValues.push(t.objectProperty(t.stringLiteral(key), t.stringLiteral(obj[key].trim())));
-                }
-            }
-            else if (t.isJSXExpressionContainer(attr.value)) {
-                mainValue = attr.value.expression;
-            }
-        }
-
-        // Extract any shorthand `style-*` properties.
+        const runtimeModule = `${state.opts.moduleName}/src/runtime/styles`;
         const attributes = path.node.openingElement.attributes;
-        const spreadStyles = [];
-        let styleAttrIndex = attr ? attributes.indexOf(attr) : -1;
+        const styleItems = [];
 
+        // There are three types of relevant attributes: "style", "style-*", and spreads. All of these might include
+        // styles we must combine together. At the end of this transform, we must have only one "style" attribute, so
+        // we remove any "style" and "style-*" attributes here (spread attributes must remain intact).
         for (let i = 0; i < attributes.length; i++) {
-            const subAttr = attributes[i];
-            if (t.isJSXAttribute(subAttr)) {
-                const subAttrName = PathUtils.getJSXAttributeName(subAttr);
-                if (subAttrName.indexOf('style-') === 0) {
-                    const key = camelCaseHyphens(subAttrName.slice('style-'.length));
-                    const value = t.isJSXExpressionContainer(subAttr.value) ? subAttr.value.expression : subAttr.value;
-                    subValues.push(t.objectProperty(t.stringLiteral(key), value));
+            const styleItem = StyleItem.fromAttribute(attributes[i], i);
+            if (styleItem) {
+                styleItems.push(styleItem);
+                if (!styleItem.isSpread) {
                     attributes.splice(i--, 1);
                 }
             }
-            else if (t.isJSXSpreadAttribute(subAttr)) {
-                // If we have any spreads, we need to extract the style property
-                spreadStyles.push(t.logicalExpression('||', t.memberExpression(subAttr.argument, t.identifier('style')), t.objectExpression([])));
-                if (styleAttrIndex >= 0 && i > styleAttrIndex) {
-                    // We need the spread to come _before_ the style attribute, otherwise if it specifies a style, this will be overwritten!
-                    // So, swap them around (this is safe because we've already visited both, in the loop)
-                    attributes[styleAttrIndex] = subAttr;
-                    attributes[i] = attr;
-                    styleAttrIndex = i;
-                }
-            }
         }
 
-        // These are the styles we need to combine at runtime
-        let numSpreadStyles = spreadStyles.length;
-        let stylesToCombine = spreadStyles;
-        if (subValues.length) {
-            stylesToCombine.unshift(t.objectExpression(subValues));
-        }
-        if (mainValue) {
-            stylesToCombine.unshift(mainValue);
-        }
-
-        // Do we need to do anything? If there are no styles to combine, or there's only a single spread style, we can bail now
-        if (!stylesToCombine.length || (stylesToCombine.length === 1 && numSpreadStyles === 1)) {
+        // If there weren't any styles, or we only had one spread, leave the element as-is (we haven't changed it).
+        if (styleItems.length === 0 || (styleItems.length === 1 && styleItems[0].isSpread)) {
             return;
         }
 
-        // If the user didn't provide a style attribute, add if necessary.
-        if (!attr) {
-            const attributes = path.node.openingElement.attributes;
-            attr = t.jSXAttribute(t.jSXIdentifier('style'), null);
-            attributes.push(attr);
+        // Combine styles into as few items as possible (e.g. multiple shorthands can be combined into one object).
+        // NOTE: We cannot merge anything out-of-order, so a simple pairwise iteration is optimal.
+        for (let i = 1; i < styleItems.length; i++) {
+            if (styleItems[i - 1].tryToMerge(styleItems[i])) {
+                styleItems.splice(i--, 1);
+            }
         }
 
-        // We need a runtime transform to combine the styles, even if there's only one style to combine,
-        // because React does not support passing a string to the style attribute, and some users
-        // use style={`some: string`}.
-        // TODO: We can be cleverer, and use a template string expression as a special case to avoid the runtime transform.
-        const runtimeTransformName = PathUtils.addImportOnce(path,
-            'default', `${state.opts.moduleName}/src/runtime/styles`, { nameHint: 'S' });
-        attr.value = t.jSXExpressionContainer(t.callExpression(runtimeTransformName, stylesToCombine));
+        // If only one object-literal style item is left, we can just include a style attribute with that object.
+        // Otherwise, we need the runtime transform to combine the style items.
+        const value = styleItems.length === 1 && t.isObjectExpression(styleItems[0].value)
+            ? styleItems[0].value
+            : t.callExpression(PathUtils.addImportOnce(path, 'default', runtimeModule, { nameHint: 'S' }), styleItems.map(s => s.value));
+
+        // Insert the new style attribute in the same position as the first original style attribute.
+        attributes.splice(styleItems[0].index, 0,
+            t.jSXAttribute(t.jSXIdentifier('style'), t.jSXExpressionContainer(value)));
     }
 };
+
+/**
+ * A container representing one user-specified attribute related to styles. This includes "style", "style-*", and spreads.
+ */
+class StyleItem {
+
+    /** @private */
+    constructor(value, index, isSpread) {
+        this.value = value;
+        this.index = index;
+        this.isSpread = isSpread;
+    }
+
+    /**
+     * If `attr` is a style-related attribute, return a new StyleItem representing the attribute. Otherwise return null.
+     * @param {JSXAttribute|JSXSpreadAttribute} attr
+     * @param {number} index
+     * @return {StyleItem|null}
+     */
+    static fromAttribute(attr, index) {
+        // Spreads might contain a ".style" property, which we must extract.
+        if (t.isJSXSpreadAttribute(attr)) {
+            return new StyleItem(t.logicalExpression('||', t.memberExpression(attr.argument, t.identifier('style')), t.objectExpression([])), index, true);
+        }
+        const name = PathUtils.getJSXAttributeName(attr);
+        if (name === 'style') {
+            return new StyleItem(StyleItem.convertStringsToStyleObjects(StyleItem.simplifyStringLiteral(attr.value)), index);
+        }
+        // Expand `style-foo={...}` shorthands into `style={{ foo: ... }}` for simplicity.
+        else if (name.startsWith('style-')) {
+            const key = t.stringLiteral(camelCaseHyphens(name.slice(6)));
+            const value = t.objectExpression([ t.objectProperty(key, StyleItem.simplifyStringLiteral(attr.value)) ]);
+            return new StyleItem(value, index);
+        }
+        else {
+            return null;
+        }
+    }
+
+    /**
+     * Attempt to merge another StyleItem's value into this one. We can do this if both are ObjectExpressions whose keys
+     * are simple strings or identifiers. Return true if `other` was merged into this.
+     * @param {StyleItem} other
+     * @return {boolean}
+     */
+    tryToMerge(other) {
+        // We can only combine these if they are both object literals (and not spreads).
+        if (this.isSpread || other.isSpread || !t.isObjectExpression(this.value) || !t.isObjectExpression(other.value)) {
+            return false;
+        }
+        // Start combining the objects. If we run into object keys that aren't strings/identifiers, we must abort, since
+        // we can't safely merge them.
+        let result = new Map();
+        for (let prop of this.value.properties) {
+            if (!(t.isStringLiteral(prop.key) || t.isIdentifier(prop.key))) {
+                return false;
+            }
+            result.set(prop.key.name || prop.key.value, prop);
+        }
+        for (let prop of other.value.properties) {
+            if (!(t.isStringLiteral(prop.key) || t.isIdentifier(prop.key))) {
+                return false;
+            }
+            result.set(prop.key.name || prop.key.value, prop);
+        }
+        // If we've made it this far, the objects are safe to merge.
+        this.value.properties = Array.from(result.values());
+        return true;
+    }
+
+    /**
+     * If given a string or StringLiteral, parse it as a CSS string and transform it into an ObjectExpression,
+     * returning other nodes unchanged.
+     * @param {Node} s
+     * @return {Node|ObjectExpression}
+     */
+    static convertStringsToStyleObjects(s) {
+        if (t.isStringLiteral(s)) {
+            s = s.value;
+        }
+        if (typeof s !== 'string') {
+            return s;
+        }
+        const properties = [];
+        const obj = styles(s);
+        for (let key in obj) {
+            properties.push(t.objectProperty(t.stringLiteral(key), t.stringLiteral(obj[key].trim())));
+        }
+        return t.objectExpression(properties);
+    }
+
+    /**
+     * If possible, simplify an expression containing a statically-determinable string
+     * into a plain StringLiteral node. Otherwise return the original node.
+     *
+     * @param {Node} node
+     * @return {Node} A node that is more likely to be a StringLiteral.
+     */
+    static simplifyStringLiteral(node) {
+        if (t.isJSXExpressionContainer(node)) {
+            node = node.expression;
+        }
+        // Template strings can be converted if they don't perform any interpolation.
+        if (t.isTemplateLiteral(node) && node.expressions.length === 0) {
+            return t.stringLiteral(node.quasis[0].value.cooked);
+        }
+        return node;
+    }
+}

--- a/test/fixtures/style/actual.jsx
+++ b/test/fixtures/style/actual.jsx
@@ -1,9 +1,23 @@
-<div>
-    <div style-font-size={32} style-font-weight="bold" />
-    <div style={{ color: 'white' }} style-color="red" />
-    <div style="color: white" style-font-weight="bold" />
-    <div style={'some: string'} />
-    <div style={{ color: 'white' }} style-font-weight={someJsExpression} />
-    <div { ...spreadArrayRemainsUnchanged } />
-    <div style={{ color: 'white' }} style-font-weight={someJsExpression} { ...spreadArray } />
-</div>
+
+// The following must result in one style attribute (no runtime):
+<div style-font-size={32} style-font-weight="bold" />;
+<div style={{ color: 'white' }} style-color="red" />;
+<div style="background-color: white" style-font-weight="bold" />;
+<div style={'some: string'} />;
+<div style={`some: template-string`} />;
+<div style={{ color: 'white' }} style-font-weight={someJsExpression} />;
+<div style={{ color: 'white' }} style={{ color: 'red', fontSize: 10 }} />;
+
+// The following should remain unchanged:
+<div style={{ foo: bar }} />;
+<div { ...spreadArrayRemainsUnchanged } />;
+
+// The following must require the runtime transform:
+<div style={`some: ${interpolated}-template-string`} />;
+<div style={{ color: 'white' }} style-font-weight={someJsExpression} { ...spreadArray } />;
+<div style={opaqueMaybeString} />;
+<div {...spread1} {...spread2} />;
+
+// Spread attributes must retain left-to-right evaluation order when they might include styles.
+// i.e. the resulting runtime must include s1, s2, s3, s4, s5 as arguments in order.
+<div style-1={s1} {...s2} style={s3} {...s4} style={s5} />;

--- a/test/fixtures/style/expected.jsx
+++ b/test/fixtures/style/expected.jsx
@@ -1,35 +1,66 @@
+var _C = _interopRequireDefault(require('@twist/babel-plugin-transform-react/src/runtime/classes')).default;
 var _S = _interopRequireDefault(require('@twist/babel-plugin-transform-react/src/runtime/styles')).default;
 
 function _interopRequireDefault(obj) {
-    return (obj && obj.__esModule ? obj : {
-        default: obj
-    });
+  return (obj && obj.__esModule ? obj : {
+    default: obj
+  });
 }
 
-<div>
-    <div
-        style={_S({
-            'fontSize': 32,
-            'fontWeight': "bold"
-        })} />
-    <div
-        style={_S({ color: 'white' }, {
-            'color': "red"
-        })} />
-    <div
-        style={_S({
-            'color': 'white',
-            'fontWeight': "bold"
-        })} />
-    <div style={_S('some: string')} />
-    <div
-        style={_S({ color: 'white' }, {
-            'fontWeight': someJsExpression
-        })} />
-    <div { ...spreadArrayRemainsUnchanged } />
-    <div
-        { ...spreadArray }
-        style={_S({ color: 'white' }, {
-            'fontWeight': someJsExpression
-        }, spreadArray.style || {})} />
-</div>
+// The following must result in one style attribute (no runtime):
+<div
+  style={{
+    'fontSize': 32,
+    'fontWeight': "bold"
+  }} />;
+<div style={{ 'color': "red" }} />;
+<div
+  style={{
+    'backgroundColor': 'white',
+    'fontWeight': "bold"
+  }} />;
+<div style={{
+  'some': 'string'
+}} />;
+<div style={{
+  'some': 'template-string'
+}} />;
+<div
+  style={{
+    color: 'white',
+    'fontWeight': someJsExpression
+  }} />;
+<div
+  style={{
+    color: 'red',
+    fontSize: 10
+  }} />;
+
+// The following should remain unchanged:
+<div style={{ foo: bar }} />;
+<div { ...spreadArrayRemainsUnchanged } />;
+
+// The following must require the runtime transform:
+<div style={_S(`some: ${interpolated}-template-string`)} />;
+<div
+  style={_S({
+    color: 'white',
+    'fontWeight': someJsExpression
+  }, spreadArray.style || {})}
+  { ...spreadArray } />;
+<div style={_S(opaqueMaybeString)} />;
+<div
+  style={_S(spread1.style || {}, spread2.style || {})}
+  {...spread1}
+  {...spread2}
+  className={_C([ spread1.className || '', spread2.className || '' ])} />;
+
+// Spread attributes must retain left-to-right evaluation order when they might include styles.
+// i.e. the resulting runtime must include s1, s2, s3, s4, s5 as arguments in order.
+<div
+  style={_S({
+    '1': s1
+  }, s2.style || {}, s3, s4.style || {}, s5)}
+  {...s2}
+  {...s4}
+  className={_C([ s2.className || '', s4.className || '' ])} />;

--- a/test/unit/style.jsx
+++ b/test/unit/style.jsx
@@ -62,4 +62,22 @@ describe('style', () => {
         <div style={{ fontSize: '10px' }} style-font-size={300} style-font-weight="bold" />,
         { fontSize: 300, fontWeight: 'bold' });
 
+    let s1 = { fontSize: '10px' };
+    let s2 = { fontWeight: 'bold' };
+    testStyle(
+        'merging object properties at runtime',
+        <div style={s1} style={s2} />,
+        { fontSize: '10px', fontWeight: 'bold' });
+
+    let s3 = 'font-size: 10px';
+    let s4 = 'font-weight: bold';
+    testStyle(
+        'merging string properties at runtime',
+        <div style={s3} style={s4} />,
+        { fontSize: '10px', fontWeight: 'bold' });
+
+    testStyle(
+        'merging properties',
+        <div style={{ fontSize: '10px' }} style={{ fontWeight: 'bold' }} />,
+        { fontSize: '10px', fontWeight: 'bold' });
 });


### PR DESCRIPTION
We now avoid the runtime transform whenever possible, such as when the user specifies the style as an uninterpolated template string, or when the user provides object literals to style properties.

NOTE: In both Torq and the previous implementation, we parsed spread attributes out-of-order with respect to the normal left-to-right JSX attribute precedence. In general, JSX attributes are evaluated left-to-right, with later attributes overwriting previous ones. Note the semantics of the following:

```jsx
<div attr1={A} {...B} attr2={C} {...D} />
```

In React (and by convention), these attributes would be evaulated in order from left to right, and overwritten accordingly. This behavior is commonly relied upon when passing props as spread attributes.

While React does not combine style attributes, in Twist one would expect the following:

```jsx
<div style={A} {...B} style={C} {...D} />
```

to result in a merged style of (A, B, C, D), in order. I think this is the desired behavior, which is what this patch does. One can still replicate the old Torq-style behavior by placing the spread attribute
first (to have later styles supercede earlier ones).

Let me know if you disagree with this rationale.

Additionally, the runtime transform has been optimized and simplified.