### PR TITLE
Add fix and testcase for data-uri CSS values.

### DIFF
--- a/src/runtime/styles.js
+++ b/src/runtime/styles.js
@@ -19,10 +19,19 @@ function camelCase(str) {
 
 function mergeStyleIntoObject(value, obj) {
     if (typeof value === 'string') {
-        value.split(';').forEach(function(item) {
-            const kv = item.split(':', 2);
-            if (kv.length === 2) {
-                obj[camelCase(kv[0].trim())] = kv[1].trim();
+        // NOTE: The implementation here is designed to facilitate legacy code that declares inline styles as strings;
+        // it does not implement the complete CSS parsing specification. In practice, this implementation covers nearly
+        // all cases, including "data:" URI values that would otherwise break when splitting on semicolons only. In the
+        // future, we could explore adding a compliant parser. We would need two variants: one that runs at
+        // compile-time, and one that is used in the browser. The browser implementation would be straightforward, using
+        // an element's style attribute as a conversion interface. For the compiler, as of this writing (Jan 2018), a
+        // cursory search doesn't reveal any lightweight more-compliant parsers; it's likely we'd need to use postcss.
+        value.split(/;(?!base64)/g).forEach(function(item) {
+            const colonIndex = item.indexOf(':');
+            if (colonIndex !== -1) {
+                const key = item.slice(0, colonIndex).trim();
+                const value = item.slice(colonIndex + 1).trim();
+                obj[camelCase(key)] = value;
             }
         });
     }

--- a/test/unit/style.jsx
+++ b/test/unit/style.jsx
@@ -80,4 +80,9 @@ describe('style', () => {
         'merging properties',
         <div style={{ fontSize: '10px' }} style={{ fontWeight: 'bold' }} />,
         { fontSize: '10px', fontWeight: 'bold' });
+
+    testStyle(
+        'parsing CSS with embedded colons and semicolons (data URI case)',
+        <div style="background: url(data:image/png;base64,abcde123456); color: red" />,
+        { background: 'url(data:image/png;base64,abcde123456)', color: 'red' });
 });


### PR DESCRIPTION
This PR adds a test and support for the most common case where a naïve string-splitting CSS parser falls short: parsing `data:` URIs.

As noted in the source comment, to actually be spec-correct here, we'd need to include two parsing methods, one for the compiler and one for the browser. I found that nearly all of the lightweight modules that parse styles ([example1](https://github.com/aknuds1/html-to-react/pull/33/files) [example2](https://github.com/joshwnj/style-attr/blob/master/src/index.js)) actually don't do anything more clever than this, so for the compiler we'd likely need to use postcss's parser if we want something more robust.

If it was up to me, I probably wouldn't even bother adding that as an issue -- I feel like including CSS as strings should be discouraged anyway, and I have a hard time constructing an edge case where end-users would actually see this as an issue. And, similarly, I'd hate for us to inadvertently start pulling in a bunch of PostCSS code just for this one thing (in the interest of remaining lightweight). But I defer to you, if you feel strongly that we should add real CSS parsing to our backlog.

Fixes #4.