### PR TITLE
Allow both `bind:value` and `onChange` handlers.

### DIFF
--- a/test/fixtures/bind-value/actual.jsx
+++ b/test/fixtures/bind-value/actual.jsx
@@ -2,6 +2,8 @@
     <input value={ x.value } />
     <input bind:value={ x.value } />
     <input type="text" bind:value={ value } />
+    <input bind:value={ x.value } onChange={() => unrelatedHandler()} />
+    <input bind:value={ x.value } onChange={(ev) => x.value = ev.target.value } />
     <select bind:value={ value }>
         <option value="a">A</option>
         <option value="b">B</option>

--- a/test/fixtures/bind-value/expected.jsx
+++ b/test/fixtures/bind-value/expected.jsx
@@ -2,6 +2,8 @@
     <input value={ x.value } />
     <input value={x.value} onChange={ev => x.value = ev.target.value} />
     <input type="text" value={value} onChange={ev => value = ev.target.value} />
+    <input value={x.value} onChange={ev => (x.value = ev.target.value, (() => unrelatedHandler())(ev))} />
+    <input value={x.value} onChange={ev => (x.value = ev.target.value, (ev => x.value = ev.target.value)(ev))} />
     <select value={value} onChange={ev => value = ev.target.value}>
         <option value="a">A</option>
         <option value="b">B</option>


### PR DESCRIPTION
If the user provides both `bind:value` and `onChange`, we invoke both handlers: we assign the value first (two-way binding), then call their event handler. This should be harmless in most situations:

- For those converting from Torq, we already invoke the onChange handler regardless of the two-way binding, so existing code _already_ expects their event handler to be invoked.

- If their onChange handler does the same thing as ours, it's a logical error, but is likely harmless (assigning the observable twice with the same value). This PR also emits a warning for the common case (an assignment expression inside an arrow function) indicating that this is probably incorrect.

- If their onChange handler does something else (as I described in #6), there's no problem here.


Fixes #6.
