### PR TITLE
Apply arrow-lifting transform at the Program node to ensure ordering.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "postversion": "git push && git push --tags"
   },
   "dependencies": {
-    "@twist/babel-plugin-transform": "0.1.0",
+    "@twist/babel-plugin-transform": "0.2.0",
     "babel-core": "^6.26.0",
     "babel-template": "^6.26.0",
     "babel-types": "^6.26.0"


### PR DESCRIPTION
In short, Babel does not provide a simple way to determine whether or not a `FunctionExpression` has originated from a transpiled `ArrowFunction`. (Babel 6 includes a `.shadow` property on the node, but this has been removed in Babel 7.) It would be complex to analyze the AST to reliably extract that information.

Instead, this PR explicitly runs the arrow-lifting transform on the Program node (along with the DecoratorImportTransform, which we already ran on the Program node). This ensures that our plugin will traverse the tree reliably in the { plugins-first-to-last, then presets-last-to-first } order. Provided the user configures their project with our plugin before the "env" plugin, this should give us an unobstructed view of the AST as necessary.

It could be argued that we could just move _all_ of our transforms into the Program transform, since we're taking the hit of traversing the whole AST already...

[ This PR depends on adobe/babel-plugin-transform-twist#3 ]