### PR TITLE
Bugfix/style spreads

### DIFF
--- a/src/transforms/StyleAttributeTransform.js
+++ b/src/transforms/StyleAttributeTransform.js
@@ -76,9 +76,10 @@ module.exports = class StyleAttributeTransform {
             ? styleItems[0].value
             : t.callExpression(PathUtils.addImportOnce(path, 'default', runtimeModule, { nameHint: 'S' }), styleItems.map(s => s.value));
 
-        // Insert the new style attribute in the same position as the first original style attribute.
-        attributes.splice(styleItems[0].index, 0,
-            t.jSXAttribute(t.jSXIdentifier('style'), t.jSXExpressionContainer(value)));
+        // We insert the new (computed) style attribute at the end - it's important that it comes at the end because we don't
+        // want any spreads to override our computed style attribute. (Technically if there are no spreads, it would be safe to
+        // insert it earlier, but we'll just put it at the end for consistency).
+        attributes.push(t.jSXAttribute(t.jSXIdentifier('style'), t.jSXExpressionContainer(value)));
     }
 };
 

--- a/test/fixtures/style/expected.jsx
+++ b/test/fixtures/style/expected.jsx
@@ -43,24 +43,24 @@ function _interopRequireDefault(obj) {
 // The following must require the runtime transform:
 <div style={_S(`some: ${interpolated}-template-string`)} />;
 <div
+  { ...spreadArray }
   style={_S({
     color: 'white',
     'fontWeight': someJsExpression
-  }, spreadArray.style || {})}
-  { ...spreadArray } />;
+  }, spreadArray.style || {})} />;
 <div style={_S(opaqueMaybeString)} />;
 <div
-  style={_S(spread1.style || {}, spread2.style || {})}
   {...spread1}
   {...spread2}
+  style={_S(spread1.style || {}, spread2.style || {})}
   className={_C([ spread1.className || '', spread2.className || '' ])} />;
 
 // Spread attributes must retain left-to-right evaluation order when they might include styles.
 // i.e. the resulting runtime must include s1, s2, s3, s4, s5 as arguments in order.
 <div
+  {...s2}
+  {...s4}
   style={_S({
     '1': s1
   }, s2.style || {}, s3, s4.style || {}, s5)}
-  {...s2}
-  {...s4}
   className={_C([ s2.className || '', s4.className || '' ])} />;

--- a/test/unit/style.jsx
+++ b/test/unit/style.jsx
@@ -82,6 +82,11 @@ describe('style', () => {
         { fontSize: '10px', fontWeight: 'bold' });
 
     testStyle(
+        'merging properties and spreads',
+        <div style="color: blue" style={{ fontSize: '10px' }} {...{ style: { fontWeight: 'bold' } }} />,
+        { color: 'blue', fontSize: '10px', fontWeight: 'bold' });
+
+    testStyle(
         'parsing CSS with embedded colons and semicolons (data URI case)',
         <div style="background: url(data:image/png;base64,abcde123456); color: red" />,
         { background: 'url(data:image/png;base64,abcde123456)', color: 'red' });


### PR DESCRIPTION
### What does this PR do?

Fixes bug with styles and spreads - previously `<div style={ s } { ...spread }>`, the computed style (with `s` and `spread.style`) would get overwritten by `spread.style`. Fix is to put the computed style as the last attribute (ensuring it's after any spreads).

### Checklist

- [ ] I've read the [contribution guidelines](./CONTRIBUTING.md) and the [Code of Conduct](./CODE_OF_CONDUCT.md)
- [ ] An issue has been created for this PR
- [ ] Title begins with one of the following: `Fix:`, `Update:`, `Breaking:`, or `New:`
- [ ] Title ends with a reference to the related issue(s): `(fixes #issue)` or `(refs #issue)`
- [ ] Linting and unit tests all pass (`npm test`)
- [ ] PR includes new unit tests as necessary (or will be submitted as a separate PR)
- [ ] PR includes documentation as necessary (or will be forthcoming in a separate PR)
