### PR TITLE
constructor props transform now works for any decorator that ends with Component

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "postversion": "git push && git push --tags"
   },
   "dependencies": {
-    "@twist/babel-plugin-transform": "0.2.0",
+    "@twist/babel-plugin-transform": "0.2.1",
     "babel-core": "^6.26.0",
     "babel-template": "^6.26.0",
     "babel-types": "^6.26.0"

--- a/src/transforms/ConstructorPropsTransform.js
+++ b/src/transforms/ConstructorPropsTransform.js
@@ -24,9 +24,8 @@ module.exports = class ConstructorPropsTransform {
             return;
         }
 
-        // Abort if this class isn't decorated with @Component or @VirtualComponent
-        let classDeclaration = PathUtils.findParentClassWithDecorator(path, 'Component');
-        classDeclaration = classDeclaration || PathUtils.findParentClassWithDecorator(path, 'VirtualComponent');
+        // Abort if this class isn't decorated with a decorator that ends with Component (e.g. @Component or @VirtualComponent)
+        let classDeclaration = PathUtils.findParentClassWithDecorator(path, /Component$/);
         if (!classDeclaration) {
             return;
         }

--- a/test/fixtures/constructor-props/actual.jsx
+++ b/test/fixtures/constructor-props/actual.jsx
@@ -12,6 +12,13 @@ export class NoArgsVirtual {
     }
 }
 
+@LayoutComponent
+export class NoArgsLayout {
+    constructor() {
+        super();
+    }
+}
+
 @MyDecorator
 export class NoArgsNotComponent {
     constructor() {

--- a/test/fixtures/constructor-props/expected.jsx
+++ b/test/fixtures/constructor-props/expected.jsx
@@ -14,6 +14,13 @@ export class NoArgsVirtual {
     }
 }
 
+@LayoutComponent
+export class NoArgsLayout {
+    constructor(props, context) {
+        super(props, context);
+    }
+}
+
 @MyDecorator
 export class NoArgsNotComponent {
     constructor() {


### PR DESCRIPTION
Since we're adding more component decorators, e.g. from the virtual scroller, it's silly to have to update this list all the time. So changing to the convention that we provide `super(props)` to any decorator that ends with `Component` - it's a pretty safe transform since we don't do anything if arguments are already being passed to `super()`.

This depends on https://github.com/adobe/babel-plugin-transform-twist/pull/4 - needs dependency update.