### PR TITLE
Fixes #14 - don't hoist arrow functions in non-class methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "postversion": "git push && git push --tags"
   },
   "dependencies": {
-    "@twist/babel-plugin-transform": "0.2.1",
+    "@twist/babel-plugin-transform": "0.2.2",
     "babel-core": "^6.26.0",
     "babel-template": "^6.26.0",
     "babel-types": "^6.26.0"

--- a/test/fixtures/arrow-lifting/actual.jsx
+++ b/test/fixtures/arrow-lifting/actual.jsx
@@ -24,9 +24,17 @@ class X {
         let x = 2;
         return <button onClick={ ev => this.handle(x) } onKeyPress={ ev => this.handle(a) }>Button</button>;
     }
+    test4() {
+        function f() {
+            <button onClick={ ev => handle() }>Button 1</button>;
+        }
+    }
 }
 
 if (true) {
     <button onClick={ ev => handle() }>Button 1</button>
     let fn = () => <button onClick={ ev => handle() }>Button 2</button>;
+    function f() {
+        <button onClick={ ev => handle() }>Button 1</button>;
+    }
 }

--- a/test/fixtures/arrow-lifting/expected.jsx
+++ b/test/fixtures/arrow-lifting/expected.jsx
@@ -36,9 +36,17 @@ class X {
         let x = 2;
         return <button onClick={ ev => this.handle(x) } onKeyPress={ this[_handler7] }>Button</button>;
     }
+    test4() {
+        function f() {
+            <button onClick={ ev => handle() }>Button 1</button>;
+        }
+    }
 }
 
 if (true) {
     <button onClick={ ev => handle() }>Button 1</button>
     let fn = () => <button onClick={ ev => handle() }>Button 2</button>;
+    function f() {
+        <button onClick={ ev => handle() }>Button 1</button>;
+    }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@twist/babel-plugin-transform@0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@twist/babel-plugin-transform/-/babel-plugin-transform-0.2.1.tgz#2dc5faf1a001c49f9433a2a3ab6b7f3252a1b7e8"
+"@twist/babel-plugin-transform@0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@twist/babel-plugin-transform/-/babel-plugin-transform-0.2.2.tgz#f1243f29b61ffecfff9d0286b43e54b25096baae"
   dependencies:
     babel-core "^6.26.0"
     babel-helper-module-imports "^7.0.0-beta.3"


### PR DESCRIPTION
### What does this PR do?

We no longer hoist arrow functions unless they're in a class method (or an arrow function that's within a class method). For any other functions, it's not safe because it might not belong to a class in general - and we can't tell if this was bound correctly. So to be safe, don't do it.

This depends on https://github.com/adobe/babel-plugin-transform-twist/pull/5; will update so that tests pass once that PR lands.

### Checklist

- [ ] I've read the [contribution guidelines](./CONTRIBUTING.md) and the [Code of Conduct](./CODE_OF_CONDUCT.md)
- [ ] An issue has been created for this PR
- [ ] Title begins with one of the following: `Fix:`, `Update:`, `Breaking:`, or `New:`
- [ ] Title ends with a reference to the related issue(s): `(fixes #issue)` or `(refs #issue)`
- [ ] Linting and unit tests all pass (`npm test`)
- [ ] PR includes new unit tests as necessary (or will be submitted as a separate PR)
- [ ] PR includes documentation as necessary (or will be forthcoming in a separate PR)
