### PR TITLE
Fix: 📝Adobe Legal requires contributors sign a CLA

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,13 +6,11 @@ The following are a set of guidelines to follow when contributing to this projec
 
 ## Code Of Conduct
 
-This project adheres to the Adobe [code of conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to Grp-opensourceoffice@adobe.com.
+This project adheres to the Adobe [code of conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to [Grp-opensourceoffice@adobe.com](mailto:Grp-opensourceoffice@adobe.com).
 
 ## Contributor License Agreement
 
-All third-party contributions to this project must be accompanied by a signed contributor license. This gives Adobe permission to redistribute your contributions as part of the project. A CLA process is coming soon!
-
-<!-- Sign our CLA at [SOME LINK](no link yet). You only need to submit an Adobe CLA one time, so if you have submitted one previously, you are probably good to go! -->
+All third-party contributions to this project must be accompanied by a signed contributor license. This gives Adobe permission to redistribute your contributions as part of the project. Sign our [CLA](http://opensource.adobe.com/cla.html). You only need to submit an Adobe CLA one time, so if you have submitted one previously, you are good to go!
 
 ## Code Reviews
 


### PR DESCRIPTION
### What does this PR do?

Calls out the fact that a CLA must be signed before contributions are accepted (in `CONTRIBUTING.md`).

### Checklist

- [x] I've read the [contribution guidelines](./CONTRIBUTING.md) and the [Code of Conduct](./CODE_OF_CONDUCT.md)
- [ ] An issue has been created for this PR
- [x] Title begins with one of the following: `Fix:`, `Update:`, `Breaking:`, or `New:`
- [ ] Title ends with a reference to the related issue(s): `(fixes #issue)` or `(refs #issue)`
- [x] Linting and unit tests all pass (`npm test`)
- [ ] PR includes new unit tests as necessary (or will be submitted as a separate PR)
- [ ] PR includes documentation as necessary (or will be forthcoming in a separate PR)
