### PR TITLE
Fix: fix namespace of NamedChildren.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The plugin options are as follows. If you're using this as part of React-Twist, 
     styleAttribute: true,    // Support style-backround-color={ ... } syntax, and multiple style attributes.
     classAttribute: true,    // Support class-selected={ this.isSelected } syntax, and multiple class attributes.
     controlFlow: true,       // Support structural JSX components: <if>, <else>, <elseif>, <unless>, <repeat>, <using>
-    namedChildren: true,     // Support named children, e.g. <Dialog><dialog:header>My Header</dialog:header>{ contents }</Dialog>
+    namedChildren: true,     // Support named children, e.g. <Dialog><Dialog:header>My Header</Dialog:header>{ contents }</Dialog>
     asAttribute: true,       // Support the "as" attribute as a means of providing parameters via JSX (e.g. <route:provider as={route}>...)
     bindAttribute: true,     // Support bind:value={ this.value } as a shorthand for adding an event listener to update this.value.
     arrowLifting: true,      // Automatically lift arrow functions in JSX, so they don't get recreated every time the component is rendered.
@@ -176,9 +176,9 @@ such as large blocks of content, headers, footers, etc. For instance:
 
 ```jsx
 <Dialog>
-    <dialog:header as={ title }><h1>Header { title }</h1></dialog:header>
+    <Dialog:header as={ title }><h1>Header { title }</h1></Dialog:header>
     Contents
-    <dialog:footer><div>Footer</div></dialog:footer>
+    <Dialog:footer><div>Footer</div></Dialog:footer>
 </Dialog>
 ```
 

--- a/src/transforms/NamedChildrenTransform.js
+++ b/src/transforms/NamedChildrenTransform.js
@@ -18,19 +18,19 @@ module.exports = class NamedChildrenTransform {
     static apply(path) {
         t.assertJSXElement(path.node);
         const nameRoot = path.node.openingElement.name;
-        if (!nameRoot.namespace || !t.isJSXElement(path.parent)) {
-            // Only hoist namespaced elements, and only if the parent is a JSX element
+        if (!nameRoot.namespace || !t.isJSXElement(path.parent) || path.parent.openingElement.name.name !== nameRoot.namespace.name) {
+            // Only hoist namespaced elements, and only if the parent is a JSX element, and only if namespace is the same as parent tag name
             return false;
         }
 
-        let attrName = nameRoot.namespace.name + '_' + nameRoot.name.name;
+        let attrName = nameRoot.namespace.name.toLowerCase() + '_' + nameRoot.name.name;
         let parentAttrs = path.parent.openingElement.attributes;
 
         // Check to see if we need to convert to a function
         let attrValue = PathUtils.jsxChildrenToJS(path.node.children);
         const args = PathUtils.stripAsIdentifiers(path);
         if (args && attrValue) {
-            // Convert <dialog:title as={ x }>...</dialog:title> to a function: (x) => ...
+            // Convert <Dialog:title as={ x }>...</Dialog:title> to a function: (x) => ...
             attrValue = t.arrowFunctionExpression(args, attrValue);
         }
 

--- a/test/fixtures/named-children/actual.jsx
+++ b/test/fixtures/named-children/actual.jsx
@@ -1,7 +1,7 @@
 <Dialog>
-    <dialog:header as={ title }><h1>Header { title }</h1></dialog:header>
+    <Dialog:header as={ title }><h1>Header { title }</h1></Dialog:header>
     <div>Contents 1</div>
-    <dialog:footer><div>Footer A</div></dialog:footer>
-    <dialog:footer><div>Footer B</div></dialog:footer>
+    <Dialog:footer><div>Footer A</div></Dialog:footer>
+    <Dialog:footer><div>Footer B</div></Dialog:footer>
     <div>Contents 2</div>
 </Dialog>


### PR DESCRIPTION
`Input` and `input` are not the same.
`Input` is a component, `input` is a HTMLElement.
When parent tag is `Input`, the namespace of children should be the same.

### What does this PR do?

Indicate what the changes in this PR accomplish -- whether to fix a bug, introduce a new feature, clean up documentation, etc.

### Checklist

- [x] I've read the [contribution guidelines](./CONTRIBUTING.md) and the [Code of Conduct](./CODE_OF_CONDUCT.md)
- [ ] An issue has been created for this PR
- [x] Title begins with one of the following: `Fix:`, `Update:`, `Breaking:`, or `New:`
- [ ] Title ends with a reference to the related issue(s): `(fixes #issue)` or `(refs #issue)`
- [x] Linting and unit tests all pass (`npm test`)
- [ ] PR includes new unit tests as necessary (or will be submitted as a separate PR)
- [ ] PR includes documentation as necessary (or will be forthcoming in a separate PR)
